### PR TITLE
Modify facts that didn't merge into branch before

### DIFF
--- a/src/facts/cavity-nesting-bees.md
+++ b/src/facts/cavity-nesting-bees.md
@@ -7,8 +7,8 @@ image:
   license: CC0 1.0
   url: https://pxhere.com/en/photo/1088609
 source:
-  url: https://www.beelab.umn.edu/wild-bees/wild-bees-and-houses
-  name: Wild bee nests
+  - name: Wild bee nests
+    url: https://www.beelab.umn.edu/wild-bees/wild-bees-and-houses
 category: habitat
 ---
 Thirty to fourty percent of bees find cavities to live in, such as hollow branches, stems, or dead trees. Inside, they use mud to create chambers for their eggs. Leave hollow stems of various heights from flowers and grasses in your garden to attract bees.

--- a/src/facts/field-thistle.md
+++ b/src/facts/field-thistle.md
@@ -7,8 +7,8 @@ image:
   alt: Field Thistle
   creator: Tom Potterfield
 source:
-  name: "Bees: An Identification and Native Plant Forage Guide"
-  url: https://www.pollinatorsnativeplants.com/bees-an-identification-and-native-plant-forage-guide.html
+  - name: "Bees: An Identification and Native Plant Forage Guide"
+    url: https://www.pollinatorsnativeplants.com/bees-an-identification-and-native-plant-forage-guide.html
 category: plant
 ---
 An important forage source for all pollinators, field thistle is often mistaken for invasive thistle species, and removed from land. Native thistle attracts a multitude of bees including leaf-cutter, bumble, long-horned, sweat and “small” sweat bees.

--- a/src/facts/ground-nesting-bees.md
+++ b/src/facts/ground-nesting-bees.md
@@ -7,8 +7,8 @@ image:
   url: https://www.flickr.com/photos/minicooper93402/6828563216
   creator: devra
 source:
-  name: Wild bee nests
-  url: https://www.beelab.umn.edu/wild-bees/wild-bees-and-houses
+  - name: Wild bee nests
+    url: https://www.beelab.umn.edu/wild-bees/wild-bees-and-houses
 category: habitat
 ---
 60-70% of bees live underground. They like to dig tunnels in sandy soil with nothing growing in it. Attract bees using bare, undisturbed soil around your yard.

--- a/src/facts/purple-coneflower.md
+++ b/src/facts/purple-coneflower.md
@@ -7,8 +7,8 @@ image:
   creator: Keith Ewing
   alt: Bee on Purple Coneflower
 source:
-  url: https://mnzoo.org/conservation/act-wildlife/plant-pollinators/
-  name: Minnesota Zoo
+  - name: Minnesota Zoo
+    url: https://mnzoo.org/conservation/act-wildlife/plant-pollinators/
 category: habitat
 ---
 Brightly colored purple coneflowers attract many pollinators and are also native to Minnesota.


### PR DESCRIPTION
When master was merged into the multi-source branch, some facts didn't get pulled in for some reason and caused an error since their source field hadn't been changed to type list.