### PR TITLE
Fix indentation in config.yml

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -31,8 +31,8 @@ collections:
         fields:
           - { name: name, label: Name, widget: string }
           - { name: url, label: URL, widget: string }
-     - name: tags
-       label: Tags
-       widget: list
-       field: { name: name }
+      - name: tags
+        label: Tags
+        widget: list
+        field: { name: name }
       - { name: body, label: Body, widget: markdown }


### PR DESCRIPTION
The format for tags were off by a space in config.yml causing parsing problems.