### PR TITLE
Add default values for source & tags in config.yml

### DIFF
--- a/src/cms/cms.js
+++ b/src/cms/cms.js
@@ -56,14 +56,12 @@ const FactPagePreview = ({ entry, widgetsFor, getAsset }) => {
     })
   })
 
-  const factTags = widgetsFor('tags').map(source => {
+  const factTags = widgetsFor('tags').map(tag => {
     return (
-     source.getIn(['data']))
+     tag.getIn(['data']))
   })
 
   return (
-
-
     <>
           <LargeFactCard
           className={classes.card}

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -35,5 +35,5 @@ collections:
       - name: tags
         label: Tags
         widget: list
-        default: [""]
+        default: []
       - { name: body, label: Body, widget: markdown }

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -28,6 +28,7 @@ collections:
       - name: source
         label: Fact Source
         widget: list
+        collapsed: false
         fields:
           - { name: name, label: Name, widget: string, default: "" }
           - { name: url, label: URL, widget: string, default: "" }

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -29,9 +29,10 @@ collections:
         label: Fact Source
         widget: list
         fields:
-          - { name: name, label: Name, widget: string }
-          - { name: url, label: URL, widget: string }
+          - { name: name, label: Name, widget: string, default: "" }
+          - { name: url, label: URL, widget: string, default: "" }
       - name: tags
         label: Tags
         widget: list
+        default: [""]
       - { name: body, label: Body, widget: markdown }


### PR DESCRIPTION
When creating a new fact, the preview pane won't render since there is no object with name & url fields on source for .getIn() to find. The tag field also needs to have a array with an empty string as default value since .getIn() is not a function on strings.